### PR TITLE
append string on builder

### DIFF
--- a/src/main/java/org/unitsofmeasurement/ri/format/internal/ParseException.java
+++ b/src/main/java/org/unitsofmeasurement/ri/format/internal/ParseException.java
@@ -194,7 +194,7 @@ public class ParseException extends MeasurementException {
            default:
               if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
                  String s = "0000" + Integer.toString(ch, 16);
-                 retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+                 retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
               } else {
                  retval.append(ch);
               }

--- a/src/main/java/org/unitsofmeasurement/ri/format/internal/TokenMgrError.java
+++ b/src/main/java/org/unitsofmeasurement/ri/format/internal/TokenMgrError.java
@@ -98,7 +98,7 @@ public class TokenMgrError extends Error
         default:
           if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
             String s = "0000" + Integer.toString(ch, 16);
-            retval.append("\\u" + s.substring(s.length() - 4, s.length()));
+            retval.append("\\u").append(s.substring(s.length() - 4, s.length()));
           } else {
             retval.append(ch);
           }


### PR DESCRIPTION
concat String inside one StringBuilder or StringBuffer is slow, because internally concat will create StringBuilder. No using concat in StringBuilder save memory and get the code faster.
