### PR TITLE
split abstract quantity in more classes

### DIFF
--- a/src/main/java/org/unitsofmeasurement/ri/AbstractQuantity.java
+++ b/src/main/java/org/unitsofmeasurement/ri/AbstractQuantity.java
@@ -27,7 +27,6 @@ import javax.measure.quantity.Dimensionless;
 
 import org.unitsofmeasurement.ri.format.MeasurementFormat;
 import org.unitsofmeasurement.ri.format.QuantityFormat;
-import org.unitsofmeasurement.ri.function.AbstractConverter;
 import org.unitsofmeasurement.ri.util.SI;
 
 /**
@@ -339,86 +338,7 @@ public abstract class AbstractQuantity<Q extends Quantity<Q>> implements Quantit
         return new IntegerQuantity<Q>(intValue, unit);
     }
 
-    private static final class IntegerQuantity<T extends Quantity<T>> extends AbstractQuantity<T> {
-
-        /**
-		 * 
-		 */
-//		private static final long serialVersionUID = 5355395476874521709L;
-		
-		final int value;
-
-        public IntegerQuantity(int value, Unit<T> unit) {
-        	super(unit);
-        	this.value = value;
-        }
-
-        @Override
-        public Integer getValue() {
-            return value;
-        }
-
-        // Implements Measurement
-        public double doubleValue(Unit<T> unit) {
-            return (super.unit.equals(unit)) ? value : super.unit.getConverterTo(unit).convert(value);
-        }
-
-		@Override
-		public long longValue(Unit<T> unit) {
-	        double result = doubleValue(unit);
-	        if ((result < Long.MIN_VALUE) || (result > Long.MAX_VALUE)) {
-	            throw new ArithmeticException("Overflow (" + result + ")");
-	        }
-	        return (long) result;
-		}
-
-		@Override
-		public Measurement<T, Number> add(Measurement<T, Number> that) {
-			// TODO Auto-generated method stub
-			return null;
-		}
-
-		@Override
-		public IntegerQuantity<T> substract(Measurement<T, Number> that) {
-			// TODO Auto-generated method stub
-			return null;
-		}
-
-		@Override
-		public Measurement<?, Number> multiply(Measurement<?, Number> that) {
-			// TODO Auto-generated method stub
-			return null;
-		}
-
-		@Override
-		public Measurement<?, Number> multiply(Number that) {
-			// TODO Auto-generated method stub
-			return null;
-		}
-
-		@Override
-		public Measurement<?, Number> divide(Measurement<?, Number> that) {
-			return of((double)value / that.getValue().doubleValue(), getUnit().divide(that.getUnit()));
-		}
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public AbstractQuantity<T> inverse() {
-			return (AbstractQuantity<T>) of(value, getUnit().inverse());
-		}
-
-		@Override
-		public boolean isBig() {
-			return false;
-		}
-
-		@Override
-		public Measurement<?, Number> divide(Number that) {
-			// TODO Auto-generated method stub
-			return null;
-		}
-
-    }
+    
     
     /**
      * Returns the scalar measure for the specified <code>float</code> stated in
@@ -433,82 +353,6 @@ public abstract class AbstractQuantity<Q extends Quantity<Q>> implements Quantit
         return new FloatQuantity<Q>(floatValue, unit);
     }
 
-    private static final class FloatQuantity<T extends Quantity<T>> extends AbstractQuantity<T> {
-
-        /**
-		 * 
-		 */
-//		private static final long serialVersionUID = 7857472738562215118L;
-		
-		final float value;
-
-        public FloatQuantity(float value, Unit<T> unit) {
-        	super(unit);
-            this.value = value;
-        }
-
-        @Override
-        public Float getValue() {
-            return value;
-        }
-
-        // Implements AbstractMeasurement
-        public double doubleValue(Unit<T> unit) {
-            return (super.unit.equals(unit)) ? value : super.unit.getConverterTo(unit).convert(value);
-        }
-
-		public long longValue(Unit<T> unit) {
-	        double result = doubleValue(unit);
-	        if ((result < Long.MIN_VALUE) || (result > Long.MAX_VALUE)) {
-	            throw new ArithmeticException("Overflow (" + result + ")");
-	        }
-	        return (long) result;
-		}
-
-		@Override
-		public AbstractQuantity<T> add(Measurement<T, Number> that) {
-			return of(value + that.getValue().floatValue(), getUnit()); // TODO use shift of the unit?
-		}
-
-		@Override
-		public AbstractQuantity<T> substract(Measurement<T, Number> that) {
-			return of(value - that.getValue().floatValue(), getUnit()); // TODO use shift of the unit?
-		}
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public AbstractQuantity<T> multiply(Measurement<?, Number> that) {
-			return (AbstractQuantity<T>) of(value * that.getValue().floatValue(), 
-					getUnit().multiply(that.getUnit()));
-		}
-
-		@Override
-		public Measurement<?, Number> multiply(Number that) {
-			return of(value * that.floatValue(), 
-					getUnit().multiply(that.doubleValue()));
-		}
-
-		@Override
-		public Quantity<?> divide(Measurement<?, Number> that) {
-			return of(value / that.getValue().floatValue(), getUnit().divide(that.getUnit()));
-		}
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public Quantity<T> inverse() {
-			return (AbstractQuantity<T>) of(value, getUnit().inverse());
-		}
-
-		@Override
-		public boolean isBig() {
-			return false;
-		}
-
-		@Override
-		public Measurement<?, Number> divide(Number that) {
-			return of(value / that.floatValue(), getUnit());
-		}
-    }
 
     /**
      * Returns the scalar measure for the specified <code>double</code> stated
@@ -521,75 +365,5 @@ public abstract class AbstractQuantity<Q extends Quantity<Q>> implements Quantit
     public static <Q extends Quantity<Q>> AbstractQuantity<Q> of(double doubleValue,
             Unit<Q> unit) {
         return new DoubleQuantity<Q>(doubleValue, unit);
-    }
-
-    private static final class DoubleQuantity<T extends Quantity<T>> extends AbstractQuantity<T> {
-
-        final double value;
-
-        public DoubleQuantity(double value, Unit<T> unit) {
-        	super(unit);
-            this.value = value;
-        }
-
-        @Override
-        public Double getValue() {
-            return value;
-        }
-
-
-        public double doubleValue(Unit<T> unit) {
-            return (super.unit.equals(unit)) ? value : super.unit.getConverterTo(unit).convert(value);
-        }
-
-		@Override
-		public long longValue(Unit<T> unit) {
-	        double result = doubleValue(unit);
-	        if ((result < Long.MIN_VALUE) || (result > Long.MAX_VALUE)) {
-	            throw new ArithmeticException("Overflow (" + result + ")");
-	        }
-	        return (long) result;
-		}
-
-		@Override
-		public Measurement<T, Number> add(Measurement<T, Number> that) {
-			return of(value + that.getValue().doubleValue(), getUnit()); // TODO use shift of the unit?
-		}
-
-		@Override
-		public Measurement<T, Number> substract(Measurement<T, Number> that) {
-			return of(value - that.getValue().doubleValue(), getUnit()); // TODO use shift of the unit?
-		}
-
-		@Override
-		public Measurement<?, Number> multiply(Measurement<?, Number> that) {
-			return of(value * that.getValue().doubleValue(), getUnit().multiply(that.getUnit()));
-		}
-
-		@Override
-		public Measurement<?, Number> multiply(Number that) {
-			return of(value * that.doubleValue(), getUnit());
-		}
-
-		@Override
-		public Measurement<?, Number> divide(Measurement<?, Number> that) {
-			return of(value / that.getValue().doubleValue(), getUnit().divide(that.getUnit()));
-		}
-		
-		@Override
-		public Measurement<?, Number> divide(Number that) {
-			return of(value / that.doubleValue(), getUnit());
-		}
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public AbstractQuantity<T> inverse() {
-			return (AbstractQuantity<T>) of(value, getUnit().inverse());
-		}
-
-		@Override
-		public boolean isBig() {
-			return false;
-		}
     }
 }

--- a/src/main/java/org/unitsofmeasurement/ri/DoubleQuantity.java
+++ b/src/main/java/org/unitsofmeasurement/ri/DoubleQuantity.java
@@ -1,0 +1,75 @@
+package org.unitsofmeasurement.ri;
+
+import javax.measure.Measurement;
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+class DoubleQuantity<T extends Quantity<T>> extends AbstractQuantity<T> {
+
+    final double value;
+
+    public DoubleQuantity(double value, Unit<T> unit) {
+    	super(unit);
+        this.value = value;
+    }
+
+    @Override
+    public Double getValue() {
+        return value;
+    }
+
+
+    public double doubleValue(Unit<T> unit) {
+        return (super.getUnit().equals(unit)) ? value : super.getUnit().getConverterTo(unit).convert(value);
+    }
+
+	@Override
+	public long longValue(Unit<T> unit) {
+        double result = doubleValue(unit);
+        if ((result < Long.MIN_VALUE) || (result > Long.MAX_VALUE)) {
+            throw new ArithmeticException("Overflow (" + result + ")");
+        }
+        return (long) result;
+	}
+
+	@Override
+	public Measurement<T, Number> add(Measurement<T, Number> that) {
+		return of(value + that.getValue().doubleValue(), getUnit()); // TODO use shift of the unit?
+	}
+
+	@Override
+	public Measurement<T, Number> substract(Measurement<T, Number> that) {
+		return of(value - that.getValue().doubleValue(), getUnit()); // TODO use shift of the unit?
+	}
+
+	@Override
+	public Measurement<?, Number> multiply(Measurement<?, Number> that) {
+		return of(value * that.getValue().doubleValue(), getUnit().multiply(that.getUnit()));
+	}
+
+	@Override
+	public Measurement<?, Number> multiply(Number that) {
+		return of(value * that.doubleValue(), getUnit());
+	}
+
+	@Override
+	public Measurement<?, Number> divide(Measurement<?, Number> that) {
+		return of(value / that.getValue().doubleValue(), getUnit().divide(that.getUnit()));
+	}
+	
+	@Override
+	public Measurement<?, Number> divide(Number that) {
+		return of(value / that.doubleValue(), getUnit());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public AbstractQuantity<T> inverse() {
+		return (AbstractQuantity<T>) of(value, getUnit().inverse());
+	}
+
+	@Override
+	public boolean isBig() {
+		return false;
+	}
+}

--- a/src/main/java/org/unitsofmeasurement/ri/FloatQuantity.java
+++ b/src/main/java/org/unitsofmeasurement/ri/FloatQuantity.java
@@ -1,0 +1,77 @@
+package org.unitsofmeasurement.ri;
+
+import javax.measure.Measurement;
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+class FloatQuantity<T extends Quantity<T>> extends AbstractQuantity<T> {
+
+	final float value;
+
+    public FloatQuantity(float value, Unit<T> unit) {
+    	super(unit);
+        this.value = value;
+    }
+
+    @Override
+    public Float getValue() {
+        return value;
+    }
+
+    // Implements AbstractMeasurement
+    public double doubleValue(Unit<T> unit) {
+        return (super.getUnit().equals(unit)) ? value : super.getUnit().getConverterTo(unit).convert(value);
+    }
+
+	public long longValue(Unit<T> unit) {
+        double result = doubleValue(unit);
+        if ((result < Long.MIN_VALUE) || (result > Long.MAX_VALUE)) {
+            throw new ArithmeticException("Overflow (" + result + ")");
+        }
+        return (long) result;
+	}
+
+	@Override
+	public AbstractQuantity<T> add(Measurement<T, Number> that) {
+		return of(value + that.getValue().floatValue(), getUnit()); // TODO use shift of the unit?
+	}
+
+	@Override
+	public AbstractQuantity<T> substract(Measurement<T, Number> that) {
+		return of(value - that.getValue().floatValue(), getUnit()); // TODO use shift of the unit?
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public AbstractQuantity<T> multiply(Measurement<?, Number> that) {
+		return (AbstractQuantity<T>) of(value * that.getValue().floatValue(), 
+				getUnit().multiply(that.getUnit()));
+	}
+
+	@Override
+	public Measurement<?, Number> multiply(Number that) {
+		return of(value * that.floatValue(), 
+				getUnit().multiply(that.doubleValue()));
+	}
+
+	@Override
+	public Quantity<?> divide(Measurement<?, Number> that) {
+		return of(value / that.getValue().floatValue(), getUnit().divide(that.getUnit()));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Quantity<T> inverse() {
+		return (AbstractQuantity<T>) of(value, getUnit().inverse());
+	}
+
+	@Override
+	public boolean isBig() {
+		return false;
+	}
+
+	@Override
+	public Measurement<?, Number> divide(Number that) {
+		return of(value / that.floatValue(), getUnit());
+	}
+}

--- a/src/main/java/org/unitsofmeasurement/ri/IntegerQuantity.java
+++ b/src/main/java/org/unitsofmeasurement/ri/IntegerQuantity.java
@@ -1,0 +1,80 @@
+package org.unitsofmeasurement.ri;
+
+import javax.measure.Measurement;
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+class IntegerQuantity<T extends Quantity<T>> extends AbstractQuantity<T> {
+
+	final int value;
+
+    public IntegerQuantity(int value, Unit<T> unit) {
+    	super(unit);
+    	this.value = value;
+    }
+
+    @Override
+    public Integer getValue() {
+        return value;
+    }
+
+    public double doubleValue(Unit<T> unit) {
+        return (super.getUnit().equals(unit)) ? value : super.getUnit().getConverterTo(unit).convert(value);
+    }
+
+	@Override
+	public long longValue(Unit<T> unit) {
+        double result = doubleValue(unit);
+        if ((result < Long.MIN_VALUE) || (result > Long.MAX_VALUE)) {
+            throw new ArithmeticException("Overflow (" + result + ")");
+        }
+        return (long) result;
+	}
+
+	@Override
+	public Measurement<T, Number> add(Measurement<T, Number> that) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public IntegerQuantity<T> substract(Measurement<T, Number> that) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Measurement<?, Number> multiply(Measurement<?, Number> that) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Measurement<?, Number> multiply(Number that) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public Measurement<?, Number> divide(Measurement<?, Number> that) {
+		return of((double)value / that.getValue().doubleValue(), getUnit().divide(that.getUnit()));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public AbstractQuantity<T> inverse() {
+		return (AbstractQuantity<T>) of(value, getUnit().inverse());
+	}
+
+	@Override
+	public boolean isBig() {
+		return false;
+	}
+
+	@Override
+	public Measurement<?, Number> divide(Number that) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}


### PR DESCRIPTION
Split in classes get the code more readable, and keep  safe for any one outside of the package.
