### PR TITLE
Fixes Stack Overflow on Number conversion

### DIFF
--- a/src/main/java/tec/units/ri/AbstractConverter.java
+++ b/src/main/java/tec/units/ri/AbstractConverter.java
@@ -25,10 +25,9 @@
  */
 package tec.units.ri;
 
+import javax.measure.UnitConverter;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.measure.UnitConverter;
 
 /**
  * <p> The base class for our {@link UnitConverter} implementations.</p>
@@ -100,7 +99,7 @@ public abstract class AbstractConverter implements UnitConverter {
 
     @Override
     public Number convert(Number value) {
-        return convert(Double.valueOf(value.doubleValue()));
+        return convert(value.doubleValue());
     }
 
     public abstract double convert(double value);

--- a/src/test/java/tec/units/ri/function/UnitConverterTest.java
+++ b/src/test/java/tec/units/ri/function/UnitConverterTest.java
@@ -15,18 +15,18 @@
  */
 package tec.units.ri.function;
 
-import static org.junit.Assert.*;
-import static tec.units.ri.spi.SI.*;
-import static tec.units.ri.spi.SIPrefix.*;
+import org.junit.Test;
+import tec.units.ri.quantity.Quantities;
 
 import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.UnitConverter;
 import javax.measure.quantity.Length;
 
-import org.junit.Test;
-
-import tec.units.ri.quantity.Quantities;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static tec.units.ri.spi.SI.METRE;
+import static tec.units.ri.spi.SIPrefix.CENTI;
 
 public class UnitConverterTest {
 	private Unit<Length> sourceUnit = METRE;
@@ -39,8 +39,10 @@ public class UnitConverterTest {
 		double length2 = 6.0;
 		double result1 = converter.convert(length1);
 		double result2 = converter.convert(length2);
+		Number result3 = converter.convert(new Double(length1));
 		assertEquals(400, result1, 0);
 		assertEquals(600, result2, 0);
+		assertEquals(400, result3.intValue(), 0);
 	}
 	
 	@Test


### PR DESCRIPTION
I noticed a bug in the current implementation of AbstractConverter,
causing a stack overflow. It is easily reproducible;

'
SI.METRE.getConverterTo(US.FOOT).convert(1.0);
SI.METRE.getConverterTo(US.FOOT).convert(new Double(1.0));
'
Using the converter that uses promitives number works as expected.
However, using any implementation of java.lang.Number as the parameter
causes a StackOverflow. This is due to the implementation of
convert(Number) in AbstractConverter.java.

This adds a fix and enhance a unit test to prevent regression.