### PR TITLE
Add code coverage, reformat POM to standardized form

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,385 +1,438 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>tec.units</groupId>
-	<artifactId>unit-ri</artifactId>
-	<packaging>bundle</packaging>
-	<name>Units of Measurement Reference Implementation</name>
-	<url>http://github.com/unitsofmeasurement/unit-ri</url>
-	<organization>
-		<name>Jean-Marie Dautelle, Werner Keil, V2COM</name>
-		<url>http://unitsofmeasurement.github.io</url>
-	</organization>
-	<description>Unit Standard (JSR 363) Reference Implementation.</description>
-	<parent>
-		<groupId>tec.uom</groupId>
-		<artifactId>uom-parent</artifactId>
-		<version>0.9-SNAPSHOT</version>
-	</parent>
-	<licenses>
-		<license>
-			<name>BSD</name>
-			<url>LICENSE.txt</url>
-		</license>
-	</licenses>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>tec.units</groupId>
+    <artifactId>unit-ri</artifactId>
+    <packaging>bundle</packaging>
+    <name>Units of Measurement Reference Implementation</name>
+    <url>http://github.com/unitsofmeasurement/unit-ri</url>
+    <organization>
+        <name>Jean-Marie Dautelle, Werner Keil, V2COM</name>
+        <url>http://unitsofmeasurement.github.io</url>
+    </organization>
+    <description>Unit Standard (JSR 363) Reference Implementation.</description>
+    <parent>
+        <groupId>tec.uom</groupId>
+        <artifactId>uom-parent</artifactId>
+        <version>0.9-SNAPSHOT</version>
+    </parent>
+    <licenses>
+        <license>
+            <name>BSD</name>
+            <url>LICENSE.txt</url>
+        </license>
+    </licenses>
 
-	<scm>
-		<url>https://github.com/unitsofmeasurement/unit-ri.git</url>
-	</scm>
-	<issueManagement>
-		<system>JIRA</system>
-		<url>https://java.net/jira/browse/UNITSOFMEASUREMENT</url>
-	</issueManagement>
+    <scm>
+        <url>https://github.com/unitsofmeasurement/unit-ri.git</url>
+    </scm>
+    <issueManagement>
+        <system>JIRA</system>
+        <url>https://java.net/jira/browse/UNITSOFMEASUREMENT</url>
+    </issueManagement>
 
-	<!-- ======================================================= -->
-	<!-- Build Settings -->
-	<!-- ======================================================= -->
-	<properties>
-		<jsr.version>0.9-SNAPSHOT</jsr.version>
-		<lib.version>0.9-SNAPSHOT</lib.version>
-		<jdkVersion>1.7</jdkVersion>
-		<project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
-		<maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
-		<maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
-	</properties>
+    <!-- ======================================================= -->
+    <!-- Build Settings -->
+    <!-- ======================================================= -->
+    <properties>
+        <jsr.version>0.9-SNAPSHOT</jsr.version>
+        <lib.version>0.9-SNAPSHOT</lib.version>
+        <jdkVersion>1.7</jdkVersion>
+        <project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
+        <maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
+        <maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
+    </properties>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>tec.uom.lib</groupId>
-				<artifactId>uom-lib-common</artifactId>
-				<version>${lib.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.hamcrest</groupId>
-				<artifactId>hamcrest-all</artifactId>
-				<version>1.3</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>${junit.version}</version>
-				<scope>test</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>tec.uom.lib</groupId>
+                <artifactId>uom-lib-common</artifactId>
+                <version>${lib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	<dependencies>
-		<dependency>
-			<groupId>javax.measure</groupId>
-			<artifactId>unit-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>tec.uom.lib</groupId>
-			<artifactId>uom-lib-common</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>javax.measure</groupId>
+            <artifactId>unit-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>tec.uom.lib</groupId>
+            <artifactId>uom-lib-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-	<build>
-		<plugins>
-			<!-- ======================================================= -->
-			<!-- Compilation -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>${project.build.javaVersion}</source>
-					<target>${project.build.javaVersion}</target>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
+    <build>
+        <plugins>
+            <!-- ======================================================= -->
+            <!-- Compilation -->
+            <!-- ======================================================= -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${project.build.javaVersion}</source>
+                    <target>${project.build.javaVersion}</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
 
-			<!-- ======================================================= -->
-			<!-- Source Attachment -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-			</plugin>
+            <!-- ======================================================= -->
+            <!-- Compilation -->
+            <!-- ======================================================= -->
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<detectLinks>true</detectLinks>
-					<!-- excludePackageNames>package1</excludePackageNames -->
-					<keywords>true</keywords>
-					<linksource>true</linksource>
-					<failOnError>false</failOnError>
-					<!-- overview>${basedir}/overview.html</overview -->
-					<source>${maven.compile.sourceLevel}</source>
-					<!-- stylesheetfile>${basedir}/src/site/css/money-jdoc.css</stylesheetfile -->
-					<verbose>true</verbose>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.1.201405082137</version>
+                <configuration>
+                    <excludes>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <!-- FIXME FIXME Value much too low, should be 95% ideally -->
+                                            <!-- Only set this low to allow build to pass -->
+                                            <minimum>0.35</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <!-- Only set this low to allow build to pass -->
+                                            <!-- FIXME FIXME Value much too low, should be 75% at least -->
+                                            <minimum>0.20</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<!-- ======================================================= -->
-			<!-- JAR packaging -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-						</manifest>
-						<manifestEntries>
-							<Specification-Title>Units of Measurement API</Specification-Title>
-							<Specification-Version>${project.version}</Specification-Version>
-							<Specification-Vendor>${project.organization.name}</Specification-Vendor>
-							<Implementation-Vendor>Unit-API contributors</Implementation-Vendor>
-							<Implementation-URL>${project.organization.url}</Implementation-URL>
-						</manifestEntries>
-					</archive>
-				</configuration>
-			</plugin>
+            <!-- ======================================================= -->
+            <!-- Source Attachment -->
+            <!-- ======================================================= -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
 
-			<!-- ======================================================= -->
-			<!-- Packaging (OSGi bundle) -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>tec.units.ri.*</Export-Package>
-						<Private-Package>tec.units.ri.internal.*</Private-Package>
-					</instructions>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <detectLinks>true</detectLinks>
+                    <!-- excludePackageNames>package1</excludePackageNames -->
+                    <keywords>true</keywords>
+                    <linksource>true</linksource>
+                    <failOnError>false</failOnError>
+                    <!-- overview>${basedir}/overview.html</overview -->
+                    <source>${maven.compile.sourceLevel}</source>
+                    <!-- stylesheetfile>${basedir}/src/site/css/money-jdoc.css</stylesheetfile -->
+                    <verbose>true</verbose>
+                </configuration>
+            </plugin>
 
-			<!-- ======================================================= -->
-			<!-- Maven License Plugin -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>com.mycila</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<configuration>
-					<header>src/etc/header.txt</header>
-					<properties>
-						<owner>Jean-Marie Dautelle, Werner Keil, V2COM</owner>
-						<currentYear>2015</currentYear>
-					</properties>
-					<excludes>
-						<exclude>**/pom.xml</exclude>
-						<exclude>**/README</exclude>
-						<exclude>**/settings.xml</exclude>
-						<exclude>src/test/resources/**</exclude>
-						<exclude>src/main/resources/**</exclude>
-						<exclude>src/etc/**</exclude>
-						<exclude>*.css</exclude>
-						<exclude>*.jpg</exclude>
-						<exclude>*.png</exclude>
-						<exclude>*.yml</exclude>
-					</excludes>
-					<headerDefinitions>
-						<headerDefinition>src/etc/headers.xml</headerDefinition>
-					</headerDefinitions>
-					<mapping>
-						<java>JAVA_STYLE</java>
-					</mapping>
-				</configuration>
-			</plugin>
+            <!-- ======================================================= -->
+            <!-- JAR packaging -->
+            <!-- ======================================================= -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Specification-Title>Units of Measurement API</Specification-Title>
+                            <Specification-Version>${project.version}</Specification-Version>
+                            <Specification-Vendor>${project.organization.name}</Specification-Vendor>
+                            <Implementation-Vendor>Unit-API contributors</Implementation-Vendor>
+                            <Implementation-URL>${project.organization.url}</Implementation-URL>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
 
-			<!-- ======================================================= -->
-			<!-- Maven web site -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-				<configuration>
-					<locales>en</locales>
-					<inputEncoding>${project.build.sourceEncoding}</inputEncoding>
-					<outputEncoding>UTF-8</outputEncoding>
-					<reportPlugins>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-project-info-reports-plugin</artifactId>
-							<version>2.7</version>
-							<reportSets>
-								<reportSet>
-									<reports>
-										<report>index</report>
-										<report>summary</report>
-										<report>license</report>
-										<report>scm</report>
-										<report>cim</report>
-										<report>project-team</report>
-										<report>mailing-list</report>
-										<report>issue-tracking</report>
-									</reports>
-								</reportSet>
-							</reportSets>
-						</plugin>
+            <!-- ======================================================= -->
+            <!-- Packaging (OSGi bundle) -->
+            <!-- ======================================================= -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>tec.units.ri.*</Export-Package>
+                        <Private-Package>tec.units.ri.internal.*</Private-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
 
-						<!-- ======================================================= -->
-						<!-- Javadoc generation -->
-						<!-- -->
-						<!-- Do not set <docfilessubdirs> to true, since this -->
-						<!-- cause the unwanted copy of .svn sub-directories. -->
-						<!-- ======================================================= -->
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>2.9.1</version>
-							<configuration>
-								<source>${project.build.javaVersion}</source>             <!-- Enables javadoc to handle assertions present in J2SE 1.4. -->
-								<encoding>${project.build.sourceEncoding}</encoding>       <!-- The encoding of the source files. -->
-								<docencoding>${project.build.sourceEncoding}</docencoding> <!-- The encoding of the generated HTML files. -->
-								<charset>${sourceEncoding}</charset>         <!-- Specifies the HTML character set for this document. -->
-								<locale>en</locale>              <!-- Locale that javadoc uses when generating documentation. -->
-								<noqualifier>all</noqualifier>   <!-- Omit qualifying package name before class names in output. -->
-								<quiet>true</quiet>              <!-- Shuts off non-error and non-warning messages. -->
-								<keywords>true</keywords>        <!-- Adds HTML meta keyword tags to the generated files. -->
-								<!-- Creates links to existing javadoc-generated documentation of 
-									external referenced classes. -->
-								<links>
-									<link>http://docs.oracle.com/javase/7/docs/api/</link>
-								</links>
-							</configuration>
-						</plugin>
+            <!-- ======================================================= -->
+            <!-- Maven License Plugin -->
+            <!-- ======================================================= -->
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <header>src/etc/header.txt</header>
+                    <properties>
+                        <owner>Jean-Marie Dautelle, Werner Keil, V2COM</owner>
+                        <currentYear>2015</currentYear>
+                    </properties>
+                    <excludes>
+                        <exclude>**/pom.xml</exclude>
+                        <exclude>**/README</exclude>
+                        <exclude>**/settings.xml</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                        <exclude>src/main/resources/**</exclude>
+                        <exclude>src/etc/**</exclude>
+                        <exclude>*.css</exclude>
+                        <exclude>*.jpg</exclude>
+                        <exclude>*.png</exclude>
+                        <exclude>*.yml</exclude>
+                    </excludes>
+                    <headerDefinitions>
+                        <headerDefinition>src/etc/headers.xml</headerDefinition>
+                    </headerDefinitions>
+                    <mapping>
+                        <java>JAVA_STYLE</java>
+                    </mapping>
+                </configuration>
+            </plugin>
 
-						<!-- ======================================================= -->
-						<!-- Code analysis -->
-						<!-- ======================================================= -->
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-pmd-plugin</artifactId>
-							<version>3.0.1</version>
-							<configuration>
-								<sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-								<targetJdk>${project.build.javaVersion}</targetJdk>
-							</configuration>
-						</plugin>
+            <!-- ======================================================= -->
+            <!-- Maven web site -->
+            <!-- ======================================================= -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <configuration>
+                    <locales>en</locales>
+                    <inputEncoding>${project.build.sourceEncoding}</inputEncoding>
+                    <outputEncoding>UTF-8</outputEncoding>
+                    <reportPlugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-project-info-reports-plugin</artifactId>
+                            <version>2.7</version>
+                            <reportSets>
+                                <reportSet>
+                                    <reports>
+                                        <report>index</report>
+                                        <report>summary</report>
+                                        <report>license</report>
+                                        <report>scm</report>
+                                        <report>cim</report>
+                                        <report>project-team</report>
+                                        <report>mailing-list</report>
+                                        <report>issue-tracking</report>
+                                    </reports>
+                                </reportSet>
+                            </reportSets>
+                        </plugin>
 
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-surefire-plugin</artifactId>
-							<configuration>
-								<testFailureIgnore>false</testFailureIgnore>
-							</configuration>
-						</plugin>
+                        <!-- ======================================================= -->
+                        <!-- Javadoc generation -->
+                        <!-- -->
+                        <!-- Do not set <docfilessubdirs> to true, since this -->
+                        <!-- cause the unwanted copy of .svn sub-directories. -->
+                        <!-- ======================================================= -->
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <version>2.9.1</version>
+                            <configuration>
+                                <source>${project.build.javaVersion}</source>             <!-- Enables javadoc to handle assertions present in J2SE 1.4. -->
+                                <encoding>${project.build.sourceEncoding}</encoding>       <!-- The encoding of the source files. -->
+                                <docencoding>${project.build.sourceEncoding}</docencoding> <!-- The encoding of the generated HTML files. -->
+                                <charset>${sourceEncoding}</charset>         <!-- Specifies the HTML character set for this document. -->
+                                <locale>en</locale>              <!-- Locale that javadoc uses when generating documentation. -->
+                                <noqualifier>all</noqualifier>   <!-- Omit qualifying package name before class names in output. -->
+                                <quiet>true</quiet>              <!-- Shuts off non-error and non-warning messages. -->
+                                <keywords>true</keywords>        <!-- Adds HTML meta keyword tags to the generated files. -->
+                                <!-- Creates links to existing javadoc-generated documentation of 
+                                external referenced classes. -->
+                                <links>
+                                    <link>http://docs.oracle.com/javase/7/docs/api/</link>
+                                </links>
+                            </configuration>
+                        </plugin>
 
-						<!-- ======================================================= -->
-						<!-- Report on test results -->
-						<!-- ======================================================= -->
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-surefire-report-plugin</artifactId>
-							<version>2.10</version>
-						</plugin>
+                        <!-- ======================================================= -->
+                        <!-- Code analysis -->
+                        <!-- ======================================================= -->
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-pmd-plugin</artifactId>
+                            <version>3.0.1</version>
+                            <configuration>
+                                <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                                <targetJdk>${project.build.javaVersion}</targetJdk>
+                            </configuration>
+                        </plugin>
 
-						<!-- ======================================================= -->
-						<!-- Report on test coverage -->
-						<!-- ======================================================= -->
-						<plugin>
-							<groupId>org.codehaus.mojo</groupId>
-							<artifactId>emma-maven-plugin</artifactId>
-							<version>1.0-alpha-3</version>
-							<reportSets>
-								<reportSet></reportSet>
-								<reportSet></reportSet>
-							</reportSets>
-						</plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <testFailureIgnore>false</testFailureIgnore>
+                            </configuration>
+                        </plugin>
 
-						<!-- ======================================================= -->
-						<!-- Static analysis for occurences of bug patterns -->
-						<!-- ======================================================= -->
-						<!-- plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>findbugs-maven-plugin</artifactId> 
-							<version>2.5.2</version> </plugin> <plugin> <groupId>org.apache.maven.plugins</groupId> 
-							<artifactId>maven-checkstyle-plugin</artifactId> <version>2.11</version> 
-							<configuration> <configLocation>src/etc/checkstyle.xml</configLocation> </configuration> 
-							</plugin -->
-					</reportPlugins>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+                        <!-- ======================================================= -->
+                        <!-- Report on test results -->
+                        <!-- ======================================================= -->
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-report-plugin</artifactId>
+                            <version>2.10</version>
+                        </plugin>
 
-	<!-- Additional repositories -->
-	<!-- Helps to resolve Parent POM and Snapshot artifacts -->
-	<repositories>
-		<repository>
-			<id>jcenter</id>
-			<name>JCenter</name>
-			<url>http://jcenter.bintray.com</url>
-		</repository>
-		<repository>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-			<id>bintray-release</id>
-			<name>libs-release</name>
-			<url>http://oss.jfrog.org/artifactory/libs-release</url>
-		</repository>
-		<repository>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<id>bintray-snapshot</id>
-			<name>libs-snapshot</name>
-			<url>http://oss.jfrog.org/artifactory/libs-snapshot</url>
-		</repository>
-		<repository>
-			<id>geotoolkit</id>
-			<name>Geotoolkit.org project</name>
-			<url>http://maven.geotoolkit.org</url>
-		</repository>
-	</repositories>
+                        <!-- ======================================================= -->
+                        <!-- Report on test coverage -->
+                        <!-- ======================================================= -->
+                        <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>emma-maven-plugin</artifactId>
+                            <version>1.0-alpha-3</version>
+                            <reportSets>
+                                <reportSet></reportSet>
+                                <reportSet></reportSet>
+                            </reportSets>
+                        </plugin>
 
-	<distributionManagement>
-		<repository>
-			<id>bintray-release</id>
-			<name>oss-jfrog-artifactory-release</name>
-			<url>https://oss.jfrog.org/artifactory/oss-release-local</url>
-		</repository>
-		<snapshotRepository>
-			<id>bintray-snapshot</id>
-			<name>oss-jfrog-artifactory-snapshot</name>
-			<url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-		</snapshotRepository>
-	</distributionManagement>
+                        <!-- ======================================================= -->
+                        <!-- Static analysis for occurences of bug patterns -->
+                        <!-- ======================================================= -->
+                        <!-- plugin> <groupId>org.codehaus.mojo</groupId> <artifactId>findbugs-maven-plugin</artifactId> 
+                        <version>2.5.2</version> </plugin> <plugin> <groupId>org.apache.maven.plugins</groupId> 
+                        <artifactId>maven-checkstyle-plugin</artifactId> <version>2.11</version> 
+                        <configuration> <configLocation>src/etc/checkstyle.xml</configLocation> </configuration> 
+                        </plugin -->
+                    </reportPlugins>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-	<profiles>
-		<profile>
-			<id>jdk6</id>
-			<properties>
-				<jdkVersion>1.6</jdkVersion>
-			</properties>
-		</profile>
-		<profile>
-			<id>jdk7</id>
-			<properties>
-				<jdkVersion>1.7</jdkVersion>
-			</properties>
-		</profile>
-		<profile>
-			<id>jdk8</id>
-			<properties>
-				<jdkVersion>1.8</jdkVersion>
-			</properties>
-		</profile>
-	</profiles>
+    <!-- Additional repositories -->
+    <!-- Helps to resolve Parent POM and Snapshot artifacts -->
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>http://jcenter.bintray.com</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray-release</id>
+            <name>libs-release</name>
+            <url>http://oss.jfrog.org/artifactory/libs-release</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>bintray-snapshot</id>
+            <name>libs-snapshot</name>
+            <url>http://oss.jfrog.org/artifactory/libs-snapshot</url>
+        </repository>
+        <repository>
+            <id>geotoolkit</id>
+            <name>Geotoolkit.org project</name>
+            <url>http://maven.geotoolkit.org</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>bintray-release</id>
+            <name>oss-jfrog-artifactory-release</name>
+            <url>https://oss.jfrog.org/artifactory/oss-release-local</url>
+        </repository>
+        <snapshotRepository>
+            <id>bintray-snapshot</id>
+            <name>oss-jfrog-artifactory-snapshot</name>
+            <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+    <profiles>
+        <profile>
+            <id>jdk6</id>
+            <properties>
+                <jdkVersion>1.6</jdkVersion>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk7</id>
+            <properties>
+                <jdkVersion>1.7</jdkVersion>
+            </properties>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <properties>
+                <jdkVersion>1.8</jdkVersion>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Adding in the Jacoco coverage plugin - which reveals some pretty bad coverage results. Only 37% line coverage & 24% compelxity coverage. Most test cases clearly needed. Also reformatted the POM file, as it was inconsistent and non-standard.