### PR TITLE
Fix a few small typos in the RI documentation

### DIFF
--- a/src/main/java/tec/units/ri/AbstractUnit.java
+++ b/src/main/java/tec/units/ri/AbstractUnit.java
@@ -136,7 +136,7 @@ public abstract class AbstractUnit<Q extends Quantity<Q>> implements Unit<Q>, Co
   /**
    * Returns the unscaled standard (SI) unit from which this unit is derived.
    * 
-   * They SI unit can be be used to identify a quantity given the unit. For example:<code> static boolean isAngularVelocity(AbstractUnit<?> unit) {
+   * The SI unit can be be used to identify a quantity given the unit. For example:<code> static boolean isAngularVelocity(AbstractUnit<?> unit) {
    * return unit.toSystemUnit().equals(RADIAN.divide(SECOND)); }
    * assert(REVOLUTION.divide(MINUTE).isAngularVelocity()); // Returns true.
    * </code>

--- a/src/main/java/tec/units/ri/package-info.java
+++ b/src/main/java/tec/units/ri/package-info.java
@@ -60,7 +60,7 @@
  *         System.out.println(REVOLUTION.divide(MINUTE).toSI());
  *
  *         // Dimension checking (allows/disallows conversions)
- *         System.out.println(ELECTRON_VOLT.isCompatible(WATT.times(HOUR)));
+ *         System.out.println(ELECTRON_VOLT.isCompatible(WATT.multiply(HOUR)));
  *
  *         // Retrieval of the unit dimension (depends upon the current model).
  *         System.out.println(ELECTRON_VOLT.getDimension());
@@ -78,8 +78,8 @@
  *
  *     Units are parameterized enforce compile-time checks of units/measures consistency, for example:[code]
  *
- *     AbstractUnit<Time> MINUTE = SECOND.times(60); // Ok.
- *     AbstractUnit<Time> MINUTE = METRE.times(60); // Compile error.
+ *     AbstractUnit<Time> MINUTE = SECOND.multiply(60); // Ok.
+ *     AbstractUnit<Time> MINUTE = METRE.multiply(60); // Compile error.
  *
  *     AbstractUnit<Pressure> HECTOPASCAL = HECTO(PASCAL); // Ok.
  *     AbstractUnit<Pressure> HECTOPASCAL = HECTO(NEWTON); // Compile error.
@@ -94,8 +94,8 @@
  *     Runtime checks of dimension consistency can be done for more complex cases.
  *
  *     [code]
- *     AbstractUnit<Area> SQUARE_FOOT = FOOT.times(FOOT).asType(Area.class); // Ok.
- *     AbstractUnit<Area> SQUARE_FOOT = FOOT.times(KELVIN).asType(Area.class); // Runtime error.
+ *     AbstractUnit<Area> SQUARE_FOOT = FOOT.multiply(FOOT).asType(Area.class); // Ok.
+ *     AbstractUnit<Area> SQUARE_FOOT = FOOT.multiply(KELVIN).asType(Area.class); // Runtime error.
  *
  *     AbstractUnit<Temperature> KELVIN = AbstractUnit.of("K").asType(Temperature.class); // Ok.
  *     AbstractUnit<Temperature> KELVIN = AbstractUnit.of("kg").asType(Temperature.class); // Runtime error.

--- a/src/main/java/tec/units/ri/quantity/FloatQuantity.java
+++ b/src/main/java/tec/units/ri/quantity/FloatQuantity.java
@@ -35,7 +35,7 @@ import javax.measure.Unit;
 import tec.units.ri.AbstractQuantity;
 
 /**
- * An amount of quantity, consisting of a double and a Unit. FloatQuantity objects are immutable.
+ * An amount of quantity, consisting of a float and a Unit. FloatQuantity objects are immutable.
  * 
  * @see AbstractQuantity
  * @see Quantity

--- a/src/main/java/tec/units/ri/quantity/IntegerQuantity.java
+++ b/src/main/java/tec/units/ri/quantity/IntegerQuantity.java
@@ -35,7 +35,7 @@ import javax.measure.Unit;
 import tec.units.ri.AbstractQuantity;
 
 /**
- * An amount of quantity, consisting of a double and a Unit. IntegerQuantity objects are immutable.
+ * An amount of quantity, consisting of an integer and a Unit. IntegerQuantity objects are immutable.
  * 
  * @see AbstractQuantity
  * @see Quantity

--- a/src/main/java/tec/units/ri/quantity/LongQuantity.java
+++ b/src/main/java/tec/units/ri/quantity/LongQuantity.java
@@ -35,7 +35,7 @@ import javax.measure.Unit;
 import tec.units.ri.AbstractQuantity;
 
 /**
- * An amount of quantity, consisting of a double and a Unit. LongQuantity objects are immutable.
+ * An amount of quantity, consisting of a long and a Unit. LongQuantity objects are immutable.
  * 
  * @see AbstractQuantity
  * @see Quantity

--- a/src/main/java/tec/units/ri/quantity/NumberQuantity.java
+++ b/src/main/java/tec/units/ri/quantity/NumberQuantity.java
@@ -177,7 +177,7 @@ public class NumberQuantity<Q extends Quantity<Q>> extends AbstractQuantity<Q> {
   }
 
   /**
-   * Indicates if this measured quantity is exact. An exact quantity is guarantee exact only when stated in this quantity's unit (e.g.
+   * Indicates if this measured quantity is exact. An exact quantity is guaranteed exact only when stated in this quantity's unit (e.g.
    * <code>this.longValue()</code>); stating the quantity in any other unit may introduce conversion errors.
    * 
    * @return <code>true</code> if this quantity is exact; <code>false</code> otherwise.

--- a/src/main/java/tec/units/ri/quantity/Quantities.java
+++ b/src/main/java/tec/units/ri/quantity/Quantities.java
@@ -79,7 +79,7 @@ public final class Quantities {
   }
 
   /**
-   * Returns the scalar measurement. in the specified unit.
+   * Returns the scalar measurement in the specified unit.
    * 
    * @param value
    *          the measurement value.

--- a/src/main/java/tec/units/ri/quantity/QuantityDimension.java
+++ b/src/main/java/tec/units/ri/quantity/QuantityDimension.java
@@ -52,14 +52,12 @@ import java.util.logging.Logger;
  * The dimension associated to any given quantity are given by the published
  * {@link DimensionService} instances. For convenience, a static method
  * {@link QuantityDimension#getInstance(Class) aggregating the results of all
- * 
  * @link DimensionService} instances is provided.<br/>
  * <br/>
- *       <code>
- *        QuantityDimension speedDimension
- *            = QuantityDimension.of(Speed.class);
- *     </code>
- *       </p>
+ * <code>
+ * QuantityDimension speedDimension = QuantityDimension.of(Speed.class);
+ * </code>
+ * </p>
  *
  * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>

--- a/src/main/java/tec/units/ri/unit/MetricPrefix.java
+++ b/src/main/java/tec/units/ri/unit/MetricPrefix.java
@@ -129,7 +129,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e24)</code>.
+   * @return <code>unit.multiply(1e24)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> YOTTA(Unit<Q> unit) {
     return unit.transform(YOTTA.getConverter());
@@ -142,7 +142,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e21)</code>.
+   * @return <code>unit.multiply(1e21)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> ZETTA(Unit<Q> unit) {
     return unit.transform(ZETTA.getConverter());
@@ -155,7 +155,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e18)</code>.
+   * @return <code>unit.multiply(1e18)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> EXA(Unit<Q> unit) {
     return unit.transform(EXA.getConverter());
@@ -168,7 +168,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e15)</code>.
+   * @return <code>unit.multiply(1e15)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> PETA(Unit<Q> unit) {
     return unit.transform(PETA.getConverter());
@@ -181,7 +181,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e12)</code>.
+   * @return <code>unit.multiply(1e12)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> TERA(Unit<Q> unit) {
     return unit.transform(TERA.getConverter());
@@ -194,7 +194,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e9)</code>.
+   * @return <code>unit.multiply(1e9)</code>.
    */
   public static <Q extends Quantity<Q>> Unit<Q> GIGA(Unit<Q> unit) {
     return unit.transform(GIGA.getConverter());
@@ -259,7 +259,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-1)</code>.
+   * @return <code>unit.multiply(1e-1)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> DECI(Unit<Q> unit) {
     return unit.transform(DECI.getConverter());
@@ -285,7 +285,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-3)</code>.
+   * @return <code>unit.multiply(1e-3)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> MILLI(Unit<Q> unit) {
     return unit.transform(MILLI.getConverter());
@@ -298,7 +298,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-6)</code>.
+   * @return <code>unit.multiply(1e-6)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> MICRO(Unit<Q> unit) {
     return unit.transform(MICRO.getConverter());
@@ -311,7 +311,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-9)</code>.
+   * @return <code>unit.multiply(1e-9)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> NANO(Unit<Q> unit) {
     return unit.transform(NANO.getConverter());
@@ -324,7 +324,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-12)</code>.
+   * @return <code>unit.multiply(1e-12)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> PICO(Unit<Q> unit) {
     return unit.transform(PICO.getConverter());
@@ -337,7 +337,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-15)</code>.
+   * @return <code>unit.multiply(1e-15)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> FEMTO(Unit<Q> unit) {
     return unit.transform(FEMTO.getConverter());
@@ -350,7 +350,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-18)</code>.
+   * @return <code>unit.multiply(1e-18)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> ATTO(Unit<Q> unit) {
     return unit.transform(ATTO.getConverter());
@@ -363,7 +363,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-21)</code>.
+   * @return <code>unit.multiply(1e-21)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> ZEPTO(Unit<Q> unit) {
     return unit.transform(ZEPTO.getConverter());
@@ -376,7 +376,7 @@ public enum MetricPrefix implements SymbolSupplier, UnitConverterSupplier {
    *          The type of the quantity measured by the unit.
    * @param unit
    *          any unit.
-   * @return <code>unit.times(1e-24)</code>.
+   * @return <code>unit.multiply(1e-24)</code>.
    */
   public static final <Q extends Quantity<Q>> Unit<Q> YOCTO(Unit<Q> unit) {
     return unit.transform(YOCTO.getConverter());


### PR DESCRIPTION
- Minor spelling and punctuation issues.
- The unit times() method is nowadays named multiply().
- Cut+paste issues in comments in amount-of-quantity classes.