### PR TITLE
Correct `ParserException` constructor used in `SimpleUnitFormat.check`

### DIFF
--- a/src/main/java/tec/units/ri/format/SimpleUnitFormat.java
+++ b/src/main/java/tec/units/ri/format/SimpleUnitFormat.java
@@ -574,7 +574,7 @@ public abstract class SimpleUnitFormat extends AbstractUnitFormat {
 
     private void check(boolean expr, String message, CharSequence csq, int index) throws ParserException {
       if (!expr) {
-        throw new ParserException(message + " (in " + csq + " at index " + index + ")", index);
+        throw new ParserException(message + " (in " + csq + " at index " + index + ")", csq, index);
       }
     }
 


### PR DESCRIPTION
Resolve: #68