### PR TITLE
Changing year length to 365.2425 days.

### DIFF
--- a/src/main/java/tec/units/ri/unit/Units.java
+++ b/src/main/java/tec/units/ri/unit/Units.java
@@ -376,7 +376,7 @@ public class Units extends AbstractSystemOfUnits implements Nameable {
   /**
    * A time unit accepted for use with SI units (standard name <code>y</code> ).
    */
-  public static final Unit<Time> YEAR = addUnit(Units.DAY.multiply(365.2525));
+  public static final Unit<Time> YEAR = addUnit(Units.DAY.multiply(365.2425));
   // using Gregorian year instead of Julian (365.25)
 
   static {


### PR DESCRIPTION
Since a Gregorian year has 97 leap years each 400 years the mean year length is:
(97×366+303×365)/400=365.2425
